### PR TITLE
feat: allow continuous integration team to bypass push restrictions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "github_branch_protection" "repositories" {
   for_each          = var.repositories
   repository_id     = github_repository.repositories[each.key].node_id
   pattern           = "*"
-  push_restrictions = [github_team.teams["continuous-integration"].node_id]
+  push_restrictions = [data.github_user.mage-os-ci.node_id]
 
   required_status_checks {
     strict   = true

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "github_branch_protection" "repositories" {
   for_each          = var.repositories
   repository_id     = github_repository.repositories[each.key].node_id
   pattern           = "*"
-  push_restrictions = []
+  push_restrictions = [github_team.teams["continuous-integration"].node_id]
 
   required_status_checks {
     strict   = true


### PR DESCRIPTION
@Vinai and I were investigating why https://github.com/mage-os/mageos-inventory/actions/runs/3376794714/jobs/5613678442 failed.

The current theory is that there is no way to allow the job `GITHUB_TOKEN` to overcome branch protections. As a different solution, we instead leverage https://github.com/mage-os/infrastructure/pull/25 and a new organization token to allow the `mage-os-ci` user (a member of the `continuous-integration` team) to overcome the branch protection on the repos.