### PR TITLE
Add four new repos

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -110,6 +110,16 @@ variable "mirror_repositories" {
       description = "Mage-OS mirror fork of https://github.com/magento/zf1."
       teams       = ["continuous-integration"]
     }
+
+    mirror-magento-cloud-patches = {
+      description = "This is a Mage-OS fork of the Magento Cloud Patches project found at https://github.com/magento/magento-cloud-patches."
+      teams       = ["infrastructure"]
+    }
+
+    mirror-quality-patches = {
+      description = "This is a Mage-OS fork of the Magento Quality Patches Tool project found at https://github.com/magento/quality-patches."
+      teams       = ["infrastructure"]
+    }
   }
 }
 
@@ -183,16 +193,6 @@ variable "repositories" {
 
     infrastructure = {
       description = "Mage-OS organization infrastructure discussion and GitHub Actions."
-      teams       = ["infrastructure"]
-    }
-
-    mage-os-mirror-magento-cloud-patches = {
-      description = "This is a Mage-OS fork of the Magento Cloud Patches project found at https://github.com/magento/magento-cloud-patches."
-      teams       = ["infrastructure"]
-    }
-
-    mage-osmirror-quality-patches = {
-      description = "This is a Mage-OS fork of the Magento Quality Patches Tool project found at https://github.com/magento/quality-patches."
       teams       = ["infrastructure"]
     }
 

--- a/variables.tf
+++ b/variables.tf
@@ -191,7 +191,7 @@ variable "repositories" {
       teams       = ["infrastructure"]
     }
 
-    mage-os-mirror-quality-patches = {
+    mage-osmirror-quality-patches = {
       description = "This is a Mage-OS fork of the Magento Quality Patches Tool project found at https://github.com/magento/quality-patches."
       teams       = ["infrastructure"]
     }
@@ -269,7 +269,7 @@ variable "repositories" {
 
     meta = {
       description = "This is a Mage-OS repo for documents like the contribution/review guidelines."
-      teams       = [
+      teams = [
         "tech-lead",
         "infrastructure",
         "content",

--- a/variables.tf
+++ b/variables.tf
@@ -186,6 +186,16 @@ variable "repositories" {
       teams       = ["infrastructure"]
     }
 
+    mage-os/mirror-magento-cloud-patches = {
+      description = "This is a Mage-OS fork of the Magento Cloud Patches project found at https://github.com/magento/magento-cloud-patches."
+      teams       = ["infrastructure"]
+    }
+
+    mage-os/mirror-quality-patches = {
+      description = "This is a Mage-OS fork of the Magento Quality Patches Tool project found at https://github.com/magento/quality-patches."
+      teams       = ["infrastructure"]
+    }
+
     mage-os-website = {
       description  = "Source of the mage-os.org website."
       teams        = ["content"]
@@ -247,9 +257,25 @@ variable "repositories" {
       teams       = ["distribution"]
     }
 
+    mageos-async-events = {
+      description = "This is a Mage-OS repo for the porting of the Magento Asynchronous Events project found at https://github.com/aligent/magento-async-events."
+      teams       = ["distribution"]
+    }
+
     namespace = {
       description = "This repository serves to register the mage-os packagist namespace."
       teams       = ["infrastructure"]
+    }
+
+    meta = {
+      description = "This is a Mage-OS repo for documents like the contribution/review guidelines."
+      teams       = [
+        "tech-lead",
+        "infrastructure",
+        "content",
+        "distribution",
+        "continuous-integration"
+      ]
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -72,7 +72,7 @@ variable "mirror_repositories" {
     }
 
     mirror-magento-cloud-patches = {
-      description = "Mage-OS mirror fork of the https://github.com/magento/magento-cloud-patches."
+      description = "Mage-OS mirror fork of https://github.com/magento/magento-cloud-patches."
       teams       = ["continuous-integration"]
     }
 
@@ -203,7 +203,7 @@ variable "repositories" {
     }
 
     mageos-async-events = {
-      description = "This is a Mage-OS repo for the porting of the Magento Asynchronous Events project found at https://github.com/aligent/magento-async-events."
+      description = "This is a Mage-OS repo for the porting of the Magento Asynchronous Events Project found at https://github.com/aligent/magento-async-events."
       teams       = ["distribution"]
     }
 
@@ -253,7 +253,7 @@ variable "repositories" {
     }
 
     mageos-security-package = {
-      description = "This is a Mage-OS fork of the Magento Security Extensions project found at https://github.com/magento/security-package."
+      description = "This is a Mage-OS fork of the Magento Security Extensions Project found at https://github.com/magento/security-package."
       teams       = ["distribution"]
     }
 

--- a/variables.tf
+++ b/variables.tf
@@ -186,12 +186,12 @@ variable "repositories" {
       teams       = ["infrastructure"]
     }
 
-    mage-os/mirror-magento-cloud-patches = {
+    mage-os-mirror-magento-cloud-patches = {
       description = "This is a Mage-OS fork of the Magento Cloud Patches project found at https://github.com/magento/magento-cloud-patches."
       teams       = ["infrastructure"]
     }
 
-    mage-os/mirror-quality-patches = {
+    mage-os-mirror-quality-patches = {
       description = "This is a Mage-OS fork of the Magento Quality Patches Tool project found at https://github.com/magento/quality-patches."
       teams       = ["infrastructure"]
     }

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,11 @@ variable "mirror_repositories" {
       teams       = ["continuous-integration"]
     }
 
+    mirror-magento-cloud-patches = {
+      description = "Mage-OS mirror fork of the https://github.com/magento/magento-cloud-patches."
+      teams       = ["continuous-integration"]
+    }
+
     mirror-magento-composer-installer = {
       description = "Mage-OS mirror fork of https://github.com/magento/magento-composer-installer."
       teams       = ["continuous-integration"]
@@ -101,6 +106,11 @@ variable "mirror_repositories" {
       teams       = ["continuous-integration"]
     }
 
+    mirror-quality-patches = {
+      description = "Mage-OS mirror fork of https://github.com/magento/quality-patches."
+      teams       = ["continuous-integration"]
+    }
+
     mirror-security-package = {
       description = "Mage-OS mirror fork of https://github.com/magento/security-package."
       teams       = ["continuous-integration"]
@@ -110,26 +120,36 @@ variable "mirror_repositories" {
       description = "Mage-OS mirror fork of https://github.com/magento/zf1."
       teams       = ["continuous-integration"]
     }
-
-    mirror-magento-cloud-patches = {
-      description = "This is a Mage-OS fork of the Magento Cloud Patches project found at https://github.com/magento/magento-cloud-patches."
-      teams       = ["infrastructure"]
-    }
-
-    mirror-quality-patches = {
-      description = "This is a Mage-OS fork of the Magento Quality Patches Tool project found at https://github.com/magento/quality-patches."
-      teams       = ["infrastructure"]
-    }
   }
 }
 
 variable "teams" {
   default = {
-    tech-lead = {
-      name        = "Tech-lead"
-      description = "Technical leaders"
+    content = {
+      name        = "Content"
+      description = "Content mergers"
+      members = [
+        "johnhughes1984",
+        "wigman",
+        "Vinai",
+      ]
+    }
+
+    continuous-integration = {
+      name        = "Continuous Integration"
+      description = "Continuous Integration"
+      members = [
+        "mage-os-ci",
+      ]
+    }
+
+    distribution = {
+      name        = "Distribution"
+      description = "Distribution mergers"
       members = [
         "Vinai",
+        "sprankhub",
+        "damienwebdev",
       ]
     }
 
@@ -144,31 +164,11 @@ variable "teams" {
       ]
     }
 
-    content = {
-      name        = "Content"
-      description = "Content mergers"
-      members = [
-        "johnhughes1984",
-        "wigman",
-        "Vinai",
-      ]
-    }
-
-    distribution = {
-      name        = "Distribution"
-      description = "Distribution mergers"
+    tech-lead = {
+      name        = "Tech-lead"
+      description = "Technical leaders"
       members = [
         "Vinai",
-        "sprankhub",
-        "damienwebdev",
-      ]
-    }
-
-    continuous-integration = {
-      name        = "Continuous Integration"
-      description = "Continuous Integration"
-      members = [
-        "mage-os-ci",
       ]
     }
   }
@@ -176,11 +176,6 @@ variable "teams" {
 
 variable "repositories" {
   default = {
-    terraform = {
-      description = "Terraform files for managing the organization repository permissions."
-      teams       = ["infrastructure"]
-    }
-
     dev-env-gitpod = {
       description = "Mage-OS development environment via Gitpod."
       teams       = ["infrastructure"]
@@ -204,6 +199,11 @@ variable "repositories" {
 
     mageos-adobe-stock-integration = {
       description = "This is a Mage-OS fork of the Magento Adobe Stock Integration Project found at https://github.com/magento/adobe-stock-integration."
+      teams       = ["distribution"]
+    }
+
+    mageos-async-events = {
+      description = "This is a Mage-OS repo for the porting of the Magento Asynchronous Events project found at https://github.com/aligent/magento-async-events."
       teams       = ["distribution"]
     }
 
@@ -257,16 +257,6 @@ variable "repositories" {
       teams       = ["distribution"]
     }
 
-    mageos-async-events = {
-      description = "This is a Mage-OS repo for the porting of the Magento Asynchronous Events project found at https://github.com/aligent/magento-async-events."
-      teams       = ["distribution"]
-    }
-
-    namespace = {
-      description = "This repository serves to register the mage-os packagist namespace."
-      teams       = ["infrastructure"]
-    }
-
     meta = {
       description = "This is a Mage-OS repo for documents like the contribution/review guidelines."
       teams = [
@@ -276,6 +266,16 @@ variable "repositories" {
         "distribution",
         "continuous-integration"
       ]
+    }
+
+    namespace = {
+      description = "This repository serves to register the mage-os packagist namespace."
+      teams       = ["infrastructure"]
+    }
+
+    terraform = {
+      description = "Terraform files for managing the organization repository permissions."
+      teams       = ["infrastructure"]
     }
   }
 }


### PR DESCRIPTION
This PR changes Terraform's `variables.tf` file to add the following new reports, as discussed in [this tech meeting](https://docs.google.com/document/d/1t60o_LL_a-SBQkb24cc7g2vcZhV8efZObiwtJJFVVl0/edit#):

- Magento Cloud Patches (mirror)
- Magento Quality Patches Tool (mirror)
- Magento Asynchronous Events (port)
- Meta (for documents, guidelines, etc.)