### PR TITLE
Fix commit user, fixes #52

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -167,8 +167,8 @@ resource "github_repository_file" "codeowners" {
     formatlist("@${var.organization_name}/%s", try(each.value.teams, []))
   )}"
   commit_message      = "Managed by Terraform"
-  commit_author       = "Mage-OS CI Bot"
-  commit_email        = "info+ci@mage-os.org"
+  commit_author       = "mage-os-ci"
+  commit_email        = "info@mage-os.org"
   overwrite_on_create = true
 }
 


### PR DESCRIPTION
This should fix the issue reported in #52, because the commit e-mail and user are now the ones from the [mage-os-ci](https://github.com/mage-os-ci) user.