### PR TITLE
feat: switch github-actions repo code owners to infra team

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -278,7 +278,7 @@ variable "repositories" {
 
     github-actions = {
       description = "Mage-OS GitHub Actions for the distribution repositories."
-      teams       = ["distribution"]
+      teams       = ["infrastructure"]
       topics      = ["mage-os", "devops", "qa", "ecommerce", "ci", "actions", "magento2", "github-actions", "adobecommerce"]
     }
 


### PR DESCRIPTION
So @damienwebdev isn't always set as a reviewer by default.