### PR TITLE
Update async events default branch to v4

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -318,7 +318,7 @@ variable "repositories" {
     mageos-async-events = {
       description    = "This is a Mage-OS repo for the porting of the Magento Asynchronous Events Project found at https://github.com/aligent/magento-async-events."
       teams          = ["distribution", "async-events"]
-      default_branch = "3.x"
+      default_branch = "4.x"
       topics         = ["mage-os", "magento", "ecommerce", "magento2", "adobecommerce"]
     }
 


### PR DESCRIPTION
Following the release of v4, update the default branch for `mgae-os/mageos-async-events`