### PR TITLE
Add cmuench to the infrastructure team

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -252,6 +252,7 @@ variable "teams" {
         "sprankhub",
         "damienwebdev",
         "DavidLambauer",
+        "cmuench",
       ]
     }
 


### PR DESCRIPTION
I propose adding Christian Muench to the Mage-OS infrastructure team, on account of his familiarity, skillset, and outstanding reputation. This will allow him to assist with reviewing and processing contributions to Mage-OS infrastructure matters (mirror and release generation, releases, actions, terraform, et al.) as time allows. I've discussed this with Christian, and he's on board with it.