### PR TITLE
chore: grant push_allowances to codeowners for each standard repository

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "github_branch_protection" "repositories" {
   }
 
   restrict_pushes {
-    push_allowances = try(each.value.is_part_of_monorepo, false) ? [data.github_user.mage-os-ci.node_id] : github_repository.repositories[each.key].teams
+    push_allowances = try(each.value.is_part_of_monorepo, false) ? [data.github_user.mage-os-ci.node_id] : each.value.teams
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -128,6 +128,9 @@ resource "github_branch_protection" "repositories" {
   repository_id = github_repository.repositories[each.key].node_id
   pattern       = "*"
 
+  codeowners      = github_repository.repositories[each.key].teams
+  mage_os_ci_node = data.github_user.mage-os-ci.node_id
+
   required_status_checks {
     strict   = true
     contexts = []
@@ -144,9 +147,7 @@ resource "github_branch_protection" "repositories" {
   }
 
   restrict_pushes {
-    push_allowances = try(each.value.is_part_of_monorepo, false)
-      ? [data.github_user.mage-os-ci.node_id]
-      : github_repository.repositories[each.key].teams
+    push_allowances = try(each.value.is_part_of_monorepo, false) ? [mage_os_ci_node] : codeowners
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -128,9 +128,6 @@ resource "github_branch_protection" "repositories" {
   repository_id = github_repository.repositories[each.key].node_id
   pattern       = "*"
 
-  codeowners      = github_repository.repositories[each.key].teams
-  mage_os_ci_node = data.github_user.mage-os-ci.node_id
-
   required_status_checks {
     strict   = true
     contexts = []
@@ -147,7 +144,7 @@ resource "github_branch_protection" "repositories" {
   }
 
   restrict_pushes {
-    push_allowances = try(each.value.is_part_of_monorepo, false) ? [mage_os_ci_node] : codeowners
+    push_allowances = try(each.value.is_part_of_monorepo, false) ? [data.github_user.mage-os-ci.node_id] : github_repository.repositories[each.key].teams
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,9 @@ resource "github_branch_protection" "repositories" {
   }
 
   restrict_pushes {
-    push_allowances = try(each.value.is_part_of_monorepo, false) ? [data.github_user.mage-os-ci.node_id] : []
+    push_allowances = try(each.value.is_part_of_monorepo, false)
+      ? [data.github_user.mage-os-ci.node_id]
+      : github_repository.repositories[each.key].teams
   }
 }
 


### PR DESCRIPTION
For consideration: currently codeowners can't merge pull requests. My theory is this is caused by the `push_allowances` change for monorepo setups last month.

If that's true, in theory this might fix it by granting `push_allowances` to any codeowners for each repository.

I believe the syntax is valid, but the logic is untested, so I'm opening this as a draft. Do with it what you will.