### PR TITLE
Avoid applying eComscan to archived repositories

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -244,7 +244,7 @@ resource "github_repository_file" "sansec_ecomscan_workflow" {
   repository          = github_repository.repositories[each.key].name
   branch              = github_repository.repositories[each.key].default_branch
   file                = ".github/workflows/sansec-ecomscan.yml"
-content = <<-EOT
+  content             = <<-EOT
 name: Sansec eComscan Security Scan
 
 on:

--- a/main.tf
+++ b/main.tf
@@ -244,7 +244,7 @@ resource "github_repository_file" "sansec_ecomscan_workflow" {
   repository          = github_repository.repositories[each.key].name
   branch              = github_repository.repositories[each.key].default_branch
   file                = ".github/workflows/sansec-ecomscan.yml"
-  content             = <<-EOT
+content = <<-EOT
 name: Sansec eComscan Security Scan
 
 on:
@@ -264,7 +264,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: $${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Download eComscan
@@ -275,12 +275,12 @@ jobs:
 
       - name: Run eComscan
         env:
-          ECOMSCAN_KEY: $${{ secrets.SANSEC_LICENSE_KEY }}
+          ECOMSCAN_KEY: ${{ secrets.SANSEC_LICENSE_KEY }}
         run: |
-          output=$$(./ecomscan --no-auto-update --skip-database --deep --format=csv .)
-          if [ -n "$$output" ]; then
+          output=$(./ecomscan --no-auto-update --skip-database --deep --format=csv .)
+          if [ -n "$output" ]; then
             echo "Security issues found:"
-            echo "$$output"
+            echo "$output"
             exit 1
           fi
 EOT

--- a/main.tf
+++ b/main.tf
@@ -237,7 +237,10 @@ EOT
 }
 
 resource "github_repository_file" "sansec_ecomscan_workflow" {
-  for_each            = var.repositories
+  for_each = {
+    for k, v in var.repositories : k => v
+    if !github_repository.repositories[k].archived
+  }
   repository          = github_repository.repositories[each.key].name
   branch              = github_repository.repositories[each.key].default_branch
   file                = ".github/workflows/sansec-ecomscan.yml"

--- a/main.tf
+++ b/main.tf
@@ -264,7 +264,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: $${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Download eComscan
@@ -275,7 +275,7 @@ jobs:
 
       - name: Run eComscan
         env:
-          ECOMSCAN_KEY: ${{ secrets.SANSEC_LICENSE_KEY }}
+          ECOMSCAN_KEY: $${{ secrets.SANSEC_LICENSE_KEY }}
         run: |
           output=$(./ecomscan --no-auto-update --skip-database --deep --format=csv .)
           if [ -n "$output" ]; then


### PR DESCRIPTION
When TF tried to apply eComscan to all repos, [it fails when the repo is archived](https://github.com/mage-os/terraform/actions/runs/12544967645/job/34978425117) (readonly). This PR should fix that.

This PR also fixes a double escaping problem in the generated workflow file (I thought it was necessary but it's not working)