### PR TITLE
Set up Terraform before using it

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Terraform init
         id: init
         run: terraform init


### PR DESCRIPTION
Fixes https://github.com/mage-os/terraform/actions/runs/12783081980

Ubuntu 24.04 does not include Terraform anymore, see https://github.com/actions/runner-images/issues/10636