### PR TITLE
Apply branch protection rules only for main branch

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ resource "github_branch_protection" "repositories-release-please" {
 resource "github_branch_protection" "repositories" {
   for_each      = { for key, value in var.repositories : key => value if try(value.archived, false) == false }
   repository_id = github_repository.repositories[each.key].node_id
-  pattern       = "*"
+  pattern       = github_repository.repositories[each.key].default_branch
 
   required_status_checks {
     strict   = true


### PR DESCRIPTION
I'm far from being a terraform/tofu expert, but this PR should apply branch_protection_rules only for the default branch for all repositories that are not part of the mirrors/repositories-release-please.

This PR is not really necessary but it's a bit uncomfortable to work on a repo and not be able to commit to a newly created branch, yes this is not happening if we only use forks but forks don't have access to secretes etc...

This PR comes from https://github.com/mage-os/dashboard/pull/4