### PR TITLE
Add marcelmtz to content, distribution, and infrastructure maintainers

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -233,7 +233,8 @@ variable "teams" {
         "wigman",
         "Vinai",
         "DavidLambauer",
-        "johnprendergast"
+        "johnprendergast",
+        "marcelmtz",
       ]
     }
 
@@ -254,6 +255,7 @@ variable "teams" {
         "damienwebdev",
         "rhoerr",
         "dadolun95",
+        "marcelmtz",
       ]
     }
 
@@ -268,6 +270,7 @@ variable "teams" {
         "rhoerr",
         "cmuench",
         "dadolun95",
+        "marcelmtz",
       ]
     }
 


### PR DESCRIPTION
## Summary
- Adds [@marcelmtz](https://github.com/marcelmtz) as a maintainer to the **content**, **distribution**, and **infrastructure** teams in `variables.tf`, as Mage-OS staff 

## Reference
- Follows the same pattern as #123

## Test plan
- [x] Verify `terraform plan` shows expected team membership changes
- [x] Confirm marcelmtz GitHub username is correct