### PR TITLE
Add configurable branch protection patterns per repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,8 @@ github_repository.mirrors           — mirror repos (has_issues=false, prevent_
   github_branch_protection.mirrors  — wildcard "*", only mage-os-ci can push
 github_repository.repositories      — source repos (auto_init, delete_branch_on_merge, prevent_destroy)
   github_branch_default             — custom default branches
-  github_branch_protection          — wildcard "*" for repos without custom patterns: require PR reviews (1 approval, code owner, tech-lead dismissal), team/user push restrictions
-  github_branch_protection...custom — per-pattern rules for repos with branch_protection_patterns (same settings)
+  github_branch_protection          — two-tier: wildcard "*" with light rules (status checks only) for CI flexibility; monorepo sub-packages keep strict CI-only push restrictions
+  github_branch_protection...protected-branches — full protection on specific branches (PR reviews, push restrictions); uses branch_protection_patterns or defaults to repo's default branch
   github_branch_protection...release-please — release-please branch protection
   github_team_repository.teams      — team push access
   github_team_repository.tech-lead  — tech-lead gets maintain on all repos
@@ -106,5 +106,6 @@ Only `.tf` changes trigger workflows. Concurrency group `tofu-ci` prevents paral
 
 - `$${{ }}` in `github_repository_file` content is intentional — escapes GitHub Actions expressions from Terraform interpolation
 - `data.github_user.users` dynamically resolves repo `users` entries — user must exist on GitHub or plan fails
-- Branch protection uses `pattern = "*"` (all branches, not just default)
+- Branch protection uses two tiers: wildcard `"*"` with light rules on all branches + full protection on specific important branches (defaults to repo's default branch)
+- Monorepo sub-packages are the exception: they keep full wildcard protection (CI-only push on all branches)
 - `/plan` ACL is hardcoded in `tofu-plan.yml` `if` condition

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ All config lives in `variables.tf` default values.
 - `archived` (optional, bool — skips branch protection + eComscan)
 - `is_part_of_monorepo` (optional, bool — restricts push to mage-os-ci only)
 - `release_please_branch` (optional, string — adds protected branch for release-please)
+- `branch_protection_patterns` (optional, list of strings — custom branch protection patterns instead of wildcard `"*"`; each pattern gets the same PR review/push restriction rules)
 
 **`mirror_repositories`** map — key = `mirror-{upstream-name}`:
 - `description` (required), `teams` (required), `topics` (optional)
@@ -57,7 +58,8 @@ github_repository.mirrors           — mirror repos (has_issues=false, prevent_
   github_branch_protection.mirrors  — wildcard "*", only mage-os-ci can push
 github_repository.repositories      — source repos (auto_init, delete_branch_on_merge, prevent_destroy)
   github_branch_default             — custom default branches
-  github_branch_protection          — require PR reviews (1 approval, code owner, tech-lead dismissal), team/user push restrictions
+  github_branch_protection          — wildcard "*" for repos without custom patterns: require PR reviews (1 approval, code owner, tech-lead dismissal), team/user push restrictions
+  github_branch_protection...custom — per-pattern rules for repos with branch_protection_patterns (same settings)
   github_branch_protection...release-please — release-please branch protection
   github_team_repository.teams      — team push access
   github_team_repository.tech-lead  — tech-lead gets maintain on all repos

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ All config lives in `variables.tf` default values.
 - `archived` (optional, bool — skips branch protection + eComscan)
 - `is_part_of_monorepo` (optional, bool — restricts push to mage-os-ci only)
 - `release_please_branch` (optional, string — adds protected branch for release-please)
-- `branch_protection_patterns` (optional, list of strings — custom branch protection patterns instead of wildcard `"*"`; each pattern gets the same PR review/push restriction rules)
+- `branch_protection_patterns` (optional, list of strings — additional branch patterns to fully protect beyond the default branch; each pattern gets PR review/push restriction rules)
 
 **`mirror_repositories`** map — key = `mirror-{upstream-name}`:
 - `description` (required), `teams` (required), `topics` (optional)
@@ -59,7 +59,7 @@ github_repository.mirrors           — mirror repos (has_issues=false, prevent_
 github_repository.repositories      — source repos (auto_init, delete_branch_on_merge, prevent_destroy)
   github_branch_default             — custom default branches
   github_branch_protection          — two-tier: wildcard "*" with light rules (status checks only) for CI flexibility; monorepo sub-packages keep strict CI-only push restrictions
-  github_branch_protection...protected-branches — full protection on specific branches (PR reviews, push restrictions); uses branch_protection_patterns or defaults to repo's default branch
+  github_branch_protection...protected-branches — full protection on specific branches (PR reviews, push restrictions); always includes default branch, plus any branch_protection_patterns
   github_branch_protection...release-please — release-please branch protection
   github_team_repository.teams      — team push access
   github_team_repository.tech-lead  — tech-lead gets maintain on all repos

--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,7 @@ locals {
       for pattern in distinct(concat(
         try(value.branch_protection_patterns, []),
         [try(value.default_branch, "main")],
-      )) : {
+        )) : {
         repo_key = key
         repo     = value
         pattern  = pattern

--- a/variables.tf
+++ b/variables.tf
@@ -307,7 +307,7 @@ variable "repositories" {
       description                = "Mage-OS packaging implementation (JavaScript)."
       teams                      = ["infrastructure"]
       topics                     = ["mage-os", "magento", "ecommerce", "magento2", "adobecommerce"]
-      branch_protection_patterns = ["main"]
+      branch_protection_patterns = ["main", "release/*"]
     }
 
     github-actions = {

--- a/variables.tf
+++ b/variables.tf
@@ -304,16 +304,18 @@ variable "repositories" {
     },
 
     generate-mirror-repo-js = {
-      description = "Mage-OS packaging implementation (JavaScript)."
-      teams       = ["infrastructure"]
-      topics      = ["mage-os", "magento", "ecommerce", "magento2", "adobecommerce"]
+      description                = "Mage-OS packaging implementation (JavaScript)."
+      teams                      = ["infrastructure"]
+      topics                     = ["mage-os", "magento", "ecommerce", "magento2", "adobecommerce"]
+      branch_protection_patterns = ["main"]
     }
 
     github-actions = {
-      description           = "Mage-OS GitHub Actions for the distribution repositories."
-      teams                 = ["infrastructure"]
-      topics                = ["mage-os", "devops", "qa", "ecommerce", "ci", "actions", "magento2", "github-actions", "adobecommerce", "hacktoberfest"]
-      release_please_branch = "release-please--branches--main--components--github-actions"
+      description                = "Mage-OS GitHub Actions for the distribution repositories."
+      teams                      = ["infrastructure"]
+      topics                     = ["mage-os", "devops", "qa", "ecommerce", "ci", "actions", "magento2", "github-actions", "adobecommerce", "hacktoberfest"]
+      release_please_branch      = "release-please--branches--main--components--github-actions"
+      branch_protection_patterns = ["main"]
     }
 
     infrastructure = {
@@ -511,10 +513,11 @@ variable "repositories" {
     }
 
     mageos-magento2 = {
-      description    = "This is the Mage-OS fork of the Magento core at https://github.com/magento/magento2. Mage-OS is an independent nonprofit distribution of Magento Open Source. We are not associated with Adobe or Magento in any way. Issues and PRs are welcome."
-      default_branch = "main"
-      teams          = ["distribution"]
-      topics         = ["mage-os", "magento", "ecommerce", "magento2", "adobecommerce"]
+      description                = "This is the Mage-OS fork of the Magento core at https://github.com/magento/magento2. Mage-OS is an independent nonprofit distribution of Magento Open Source. We are not associated with Adobe or Magento in any way. Issues and PRs are welcome."
+      default_branch             = "main"
+      teams                      = ["distribution"]
+      topics                     = ["mage-os", "magento", "ecommerce", "magento2", "adobecommerce"]
+      branch_protection_patterns = ["main", "*-develop", "release/*"]
     }
 
     mageos-magento2-functional-testing-framework = {

--- a/variables.tf
+++ b/variables.tf
@@ -286,9 +286,10 @@ variable "teams" {
 variable "repositories" {
   default = {
     dashboard = {
-      description = "Mage-OS Dashboard showing an overview of all repositories, issues and pull requests."
-      teams       = ["infrastructure"]
-      topics      = ["mage-os", "ecommerce", "magento2", "adobecommerce"]
+      description                = "Mage-OS Dashboard showing an overview of all repositories, issues and pull requests."
+      teams                      = ["infrastructure"]
+      topics                     = ["mage-os", "ecommerce", "magento2", "adobecommerce"]
+      branch_protection_patterns = ["main"]
     },
 
     devdocs-website = {

--- a/variables.tf
+++ b/variables.tf
@@ -325,10 +325,11 @@ variable "repositories" {
     }
 
     mage-os-org = {
-      description    = "The official Mage-OS website built with Astro."
-      teams          = ["content"]
-      default_branch = "main"
-      homepage_url   = "https://mage-os.org"
+      description                = "The official Mage-OS website built with Astro."
+      teams                      = ["content"]
+      default_branch             = "main"
+      homepage_url               = "https://mage-os.org"
+      branch_protection_patterns = ["main"]
     }
 
     mage-os-website = {


### PR DESCRIPTION
Instead of always using a wildcard "*" pattern for branch protection, allow configurable branch_protection_patterns to protect only specific branches.

Applied to:
- generate-mirror-repo-js: main only
- github-actions: main only
- mageos-magento2: main, *-develop, release/*
- mage-os-org: main only

Repos without this setting keep the existing wildcard protection of all branches.  
A repo's default branch will always be protected, whether it's defined in this new config or not.

This will allow CI tooling to run and create/delete/update branches. Currently, if a * branch protection is active, after CI creates a branch (such as `upstream-merge-conflicts`), we have to change the branch protections with super privileges, delete the branch, rerun the action, then change the protections back. Setting the primary protections (require review, no force push, etc) to certain branches only via this config will allow _other_ branches to be managed by CI or regular maintainers. This should make things generally smoother and less error-prone.

I do not know the intricacies of GH branch permissions or Terraform configuration. There may be a better way to accomplish this. We'll need to review the plan preview in detail either way.